### PR TITLE
nlopt dependency missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     packages=['qcommunity'],
     install_requires=[
         'qiskit', 'qiskit_aqua', 'networkx', 'numpy', 'matplotlib', 'joblib',
-        'progressbar2', 'SALib'
+        'progressbar2', 'SALib', 'nlopt'
     ],
     zip_safe=False)


### PR DESCRIPTION
When installing in a new env, `nlopt` is missing as a dependency.