### PR TITLE
install from repos automatically (PEP-508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,12 @@ pip install -e .
 
 See `qcommunity/optimization/REPRODUCE.md` for instructions on how to reproduce the results presented in "Multistart Methods for Quantum Approximate Optimization" 
 
-### Dependencies
+### Dependency considerations
 
 #### libE
 
-Library for managing ensemble-like collections of computations (includes APOSMM discussed in the paper). Follow instructions on installation and dependencies in `https://github.com/rsln-s/libensemble_var`.
-
-After you installed all dependencies, this should work:
-
-```
-git clone git@github.com:rsln-s/libensemble_var.git
-cd libensemble_var
-pip install -e .
-```
+Library for managing ensemble-like collections of computations (includes APOSMM discussed in the paper). It installs automatically from `https://github.com/rsln-s/libensemble_var`. It requires MPI (`brew install open-mpi` on MacOS).
 
 ##### IBMQX backend
 
-Backend to run code in Qiskit Aer simulator (includes a QAOA implementation)
-
-```
-git clone git@github.com:rsln-s/ibmqxbackend.git
-cd ibmqxbackend
-git checkout tags/v1.0-multistart
-pip install -e .
-```
+Backend to run code in Qiskit Aer simulator (includes a QAOA implementation) and it is automatically from `git@github.com:rsln-s/ibmqxbackend.git@v1.0-multistart`.

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     packages=['qcommunity'],
     install_requires=[
         'qiskit', 'qiskit_aqua', 'networkx', 'numpy', 'matplotlib', 'joblib',
-        'progressbar2', 'SALib'
+        'progressbar2', 'SALib',
+        'libensemble @ git+ssh://git@github.com/rsln-s/libensemble_var#egg=libensemble&sha1=0a0d1b2bbf10ef1d8cb596e7e401f9e78db01332',
+        'ibmqxbackend @ git+ssh://git@github.com/rsln-s/ibmqxbackend@v1.0-multistart#egg=ibmqxbackend',
     ],
     zip_safe=False)


### PR DESCRIPTION
There is no need to consider the repo dependencies in a special way. After PEP-508, it is possible to set dependencies on github repos. This simplifies the installation guide.